### PR TITLE
feat: add /hello endpoint to simplehttpserver

### DIFF
--- a/02_development/00_first_application/helloworld.go
+++ b/02_development/00_first_application/helloworld.go
@@ -3,5 +3,6 @@ package main
 import "fmt"
 
 func main() {
+	// this is a print statment
 	fmt.Println("Hello World")
 }

--- a/02_development/01_simplehttpserver/simplehttp.go
+++ b/02_development/01_simplehttpserver/simplehttp.go
@@ -13,6 +13,8 @@ func HelloServer(w http.ResponseWriter, req *http.Request) {
 
 func main() {
 	fmt.Println("please connect to localhost:7777/hello")
+	// adding our function to an endpoint
 	http.HandleFunc("/hello", HelloServer)
+	// starting the server
 	log.Fatal(http.ListenAndServe(":7777", nil))
 }


### PR DESCRIPTION
- Add a print statement to `main` function in `helloworld.go`
- Add `HelloServer` function to `simplehttpserver` and map it to `/hello` endpoint
- Start the server in `simplehttp.go`

Signed-off-by: cbrgm <chris@cbrgm.net>
